### PR TITLE
Missing definition for _.any

### DIFF
--- a/underscore/underscore.d.ts
+++ b/underscore/underscore.d.ts
@@ -458,6 +458,10 @@ interface UnderscoreStatic {
 		object: _.Dictionary<T>,
 		iterator?: _.ObjectIterator<T, boolean>,
 		context?: any): boolean;
+		
+	any<T>(
+		list: _.List<T>,
+		value: T): boolean;		
 
 	/**
 	* Returns true if the value is present in the list. Uses indexOf internally,


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

Missing definition for _.any